### PR TITLE
Use global event to control process substitution from another process

### DIFF
--- a/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
+++ b/Public/Src/Sandbox/Windows/DetoursServices/SubstituteProcessExecution.cpp
@@ -260,19 +260,22 @@ static bool ShouldSubstituteShim(const wstring &command, wstring &commandArgs)
 {
     assert(g_substituteProcessExecutionShimPath != nullptr);
 
+    // CODESYNC: Keep the even name in sync with the C# side
     LPCWSTR disableProcessSubstitutionEventName = L"Local\\AnyBuild-DisableProcessSubstitution";
     unique_handle<> disableProcessSubstitutionEvent(OpenEventW(SYNCHRONIZE, FALSE, disableProcessSubstitutionEventName));
     if (!disableProcessSubstitutionEvent.isValid())
     {
         DWORD err = GetLastError();
-        Dbg(L"ShouldSubstituteShim: - Failed creating event %s: 0x%08x", disableProcessSubstitutionEventName, (int)err);
+        Dbg(L"ShouldSubstituteShim: Failed to create event %s: 0x%08x (command='%s', args='%s)", disableProcessSubstitutionEventName, (int)err,
+            command.c_str(), commandArgs.c_str());
         return false;
     }
 
     DWORD wfso = WaitForSingleObject(disableProcessSubstitutionEvent.get(), 0);
     if (wfso == WAIT_OBJECT_0)
     {
-        Dbg(L"ShouldSubstituteShim: Skip injecting shim because process substitution is globally disabled");
+        Dbg(L"ShouldSubstituteShim: Skip process substitution because it is globally disabled (command='%s', args='%s)",
+            command.c_str(), commandArgs.c_str());
         return false;
     }
 


### PR DESCRIPTION
AnyBuild client that is driving a build, decides when it is appropriate to enable or disable process substitution globally for a machine. Then substitution is disabled this allows avoiding spending time on launching the shim process only to fall back to building locally.